### PR TITLE
fix: duplicate imports & using BookService initialisation in BookListViewModel

### DIFF
--- a/BookList/BookList/View/BookList/BookListViewModel.swift
+++ b/BookList/BookList/View/BookList/BookListViewModel.swift
@@ -14,7 +14,7 @@ class BookListViewModel: ViewModel {
     var state: BookListState
 
     init(service: BookService) {
-        let books = MockBookService().bookList()
+        let books = service.bookList()
         self.state = BookListState(service: service, books: books)
     }
 

--- a/BookList/BookList/View/Utils/BookDetailImage.swift
+++ b/BookList/BookList/View/Utils/BookDetailImage.swift
@@ -8,8 +8,6 @@
 
 import SwiftUI
 
-import SwiftUI
-
 struct BookDetailImage: View {
     let image: Image
 


### PR DESCRIPTION
### changes
- Removed SwiftUI duplicate imports in `BookDetailImage`
- Using `BookService` initialisation in `BookListViewModel` rather fresh instance.